### PR TITLE
Account/safe7579 fix1271

### DIFF
--- a/accounts/safe7579/src/core/ModuleManager.sol
+++ b/accounts/safe7579/src/core/ModuleManager.sol
@@ -9,8 +9,6 @@ import { Receiver } from "erc7579/core/Receiver.sol";
 import { AccessControl } from "./AccessControl.sol";
 import { CallType, CALLTYPE_SINGLE, CALLTYPE_DELEGATECALL } from "erc7579/lib/ModeLib.sol";
 
-CallType constant CALLTYPE_STATIC = CallType.wrap(0xFE);
-
 struct FallbackHandler {
     address handler;
     CallType calltype;

--- a/accounts/safe7579/src/interfaces/IERC1271.sol
+++ b/accounts/safe7579/src/interfaces/IERC1271.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.23;
+
+interface IERC1271 {
+    /**
+     * @dev Should return whether the signature provided is valid for the provided data
+     * @param _dataHash Arbitrary length data signed on behalf of address(this)
+     * @param _signature Signature byte array associated with _data
+     *
+     * MUST return the bytes4 magic value 0x1626ba7e when function passes.
+     * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc >
+     * 0.5)
+     * MUST allow external calls
+     */
+    function isValidSignature(
+        bytes32 _dataHash,
+        bytes calldata _signature
+    )
+        external
+        view
+        returns (bytes4);
+}

--- a/accounts/safe7579/src/interfaces/ISafe.sol
+++ b/accounts/safe7579/src/interfaces/ISafe.sol
@@ -65,6 +65,8 @@ interface ISafe {
         external
         view;
 
+    function signedMessages(bytes32) external view returns (uint256);
+
     /**
      * @dev Returns the domain separator for this contract, as defined in the EIP-712 standard.
      * @return bytes32 The domain separator hash.


### PR DESCRIPTION
Added code for ERC1271, that can validate with safe's `signedMessage` and `checkSignature` features.

using CoW's domain hash encoding from here:
https://github.com/rndlabs/safe-contracts/blob/merged-efh-sigmuxer/contracts/handler/extensible/SignatureVerifierMuxer.sol#L154-L170