### PR TITLE
feat: uniswap libary functions refactored to support eth-erc20 and erc20-eth swaps

### DIFF
--- a/examples/src/AutoSavings/AutoSavings.sol
+++ b/examples/src/AutoSavings/AutoSavings.sol
@@ -99,7 +99,7 @@ contract AutoSavingToVault is ERC7579ExecutorBase, SessionKeyBase {
         // if underlying asset is not the same as the token, add a swap
         address underlying = vault.asset();
         if (params.token != underlying) {
-            Execution[] memory swap = UniswapV3Integration.approveAndSwap({
+            Execution[] memory swap = UniswapV3Integration.approveAndSwapExactInput({
                 smartAccount: msg.sender,
                 tokenIn: IERC20(params.token),
                 tokenOut: IERC20(underlying),

--- a/examples/src/DollarCostAverage/DollarCostAverage.sol
+++ b/examples/src/DollarCostAverage/DollarCostAverage.sol
@@ -70,7 +70,7 @@ contract DollarCostAverage is ERC7579ExecutorBase, SessionKeyBase {
     function dca(Params calldata params) external {
         IERC7579Account smartAccount = IERC7579Account(msg.sender);
 
-        Execution[] memory executions = UniswapV3Integration.approveAndSwap({
+        Execution[] memory executions = UniswapV3Integration.approveAndSwapExactInput({
             smartAccount: msg.sender,
             tokenIn: IERC20(params.tokenIn),
             tokenOut: IERC20(params.tokenOut),

--- a/examples/src/ScheduledTransactions/ScheduledOrders.sol
+++ b/examples/src/ScheduledTransactions/ScheduledOrders.sol
@@ -20,7 +20,7 @@ contract ScheduledOrders is SchedulingBase {
         (address tokenIn, address tokenOut, uint256 amountIn, uint160 sqrtPriceLimitX96) =
             abi.decode(executionConfig.executionData, (address, address, uint256, uint160));
 
-        Execution[] memory executions = UniswapV3Integration.approveAndSwap({
+        Execution[] memory executions = UniswapV3Integration.approveAndSwapExactInput({
             smartAccount: msg.sender,
             tokenIn: IERC20(tokenIn),
             tokenOut: IERC20(tokenOut),

--- a/packages/modulekit/src/integrations/uniswap/helpers/MainnetAddresses.sol
+++ b/packages/modulekit/src/integrations/uniswap/helpers/MainnetAddresses.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.23;
 
 address payable constant SWAPROUTER_ADDRESS = payable(0xE592427A0AEce92De3Edee1F18E0157C05861564);
-address payable constant WRAPPED_NATIVE_ADDRESS =
+address payable constant WETH_ADDRESS =
     payable(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 uint24 constant SWAPROUTER_DEFAULTFEE = 3000;

--- a/packages/modulekit/src/integrations/uniswap/helpers/MainnetAddresses.sol
+++ b/packages/modulekit/src/integrations/uniswap/helpers/MainnetAddresses.sol
@@ -2,4 +2,6 @@
 pragma solidity ^0.8.23;
 
 address payable constant SWAPROUTER_ADDRESS = payable(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+address payable constant WRAPPED_NATIVE_ADDRESS =
+    payable(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
 uint24 constant SWAPROUTER_DEFAULTFEE = 3000;

--- a/packages/modulekit/src/integrations/uniswap/v3/Uniswap.sol
+++ b/packages/modulekit/src/integrations/uniswap/v3/Uniswap.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import {
     SWAPROUTER_ADDRESS,
     SWAPROUTER_DEFAULTFEE,
-    WRAPPED_NATIVE_ADDRESS
+    WETH_ADDRESS
 } from "../helpers/MainnetAddresses.sol";
 import { ISwapRouter } from "../../interfaces/uniswap/v3/ISwapRouter.sol";
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
@@ -65,7 +65,7 @@ library UniswapV3Integration {
     {
         exec = Execution({
             target: SWAPROUTER_ADDRESS,
-            value: address(tokenIn) == WRAPPED_NATIVE_ADDRESS ? amountIn : 0,
+            value: address(tokenIn) == WETH_ADDRESS ? amountIn : 0,
             callData: abi.encodeWithSelector(
                 ISwapRouter.exactInputSingle.selector,
                 ISwapRouter.ExactInputSingleParams({
@@ -102,7 +102,7 @@ library UniswapV3Integration {
     {
         exec = Execution({
             target: SWAPROUTER_ADDRESS,
-            value: address(tokenIn) == WRAPPED_NATIVE_ADDRESS ? amountInMaximum : 0,
+            value: address(tokenIn) == WETH_ADDRESS ? amountInMaximum : 0,
             callData: abi.encodeWithSelector(
                 ISwapRouter.exactOutputSingle.selector,
                 ISwapRouter.ExactOutputSingleParams({

--- a/packages/modulekit/src/integrations/uniswap/v3/Uniswap.sol
+++ b/packages/modulekit/src/integrations/uniswap/v3/Uniswap.sol
@@ -1,18 +1,31 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { SWAPROUTER_ADDRESS, SWAPROUTER_DEFAULTFEE } from "../helpers/MainnetAddresses.sol";
+import {
+    SWAPROUTER_ADDRESS,
+    SWAPROUTER_DEFAULTFEE,
+    WRAPPED_NATIVE_ADDRESS
+} from "../helpers/MainnetAddresses.sol";
 import { ISwapRouter } from "../../interfaces/uniswap/v3/ISwapRouter.sol";
 import { IERC20 } from "forge-std/interfaces/IERC20.sol";
 import { ERC20Integration } from "../../ERC20.sol";
 import { IERC7579Account, Execution } from "../../../Accounts.sol";
 
+/// @title UniswapV3Integration
 /// @author zeroknots
-
+/// @notice This library provides functions to interact with Uniswap V3
 library UniswapV3Integration {
     using ERC20Integration for IERC20;
 
-    function approveAndSwap(
+    /// @notice Approves the Uniswap router to spend `amountIn` of `tokenIn` and then swaps
+    /// `tokenIn` for `tokenOut`
+    /// @param smartAccount The address of the smart account
+    /// @param tokenIn The token to be swapped
+    /// @param tokenOut The token to be received
+    /// @param amountIn The amount of `tokenIn` to be swapped
+    /// @param sqrtPriceLimitX96 The price limit of the swap
+    /// @return exec An array of Execution objects representing the approve and swap operations
+    function approveAndSwapExactInput(
         address smartAccount,
         IERC20 tokenIn,
         IERC20 tokenOut,
@@ -25,14 +38,25 @@ library UniswapV3Integration {
     {
         exec = new Execution[](2);
         exec[0] = ERC20Integration.approve(tokenIn, SWAPROUTER_ADDRESS, amountIn);
-        exec[1] = swapExactInputSingle(smartAccount, tokenIn, tokenOut, amountIn, sqrtPriceLimitX96);
+        exec[1] =
+            swapExactInputSingle(smartAccount, tokenIn, amountIn, tokenOut, 0, sqrtPriceLimitX96);
     }
 
+    /// @notice Swaps `amountIn` of `tokenIn` for at least `amountOutMinimum` of `tokenOut` using
+    /// the exact input method
+    /// @param smartAccount The address of the smart account
+    /// @param tokenIn The token to be swapped
+    /// @param amountIn The amount of `tokenIn` to be swapped
+    /// @param tokenOut The token to be received
+    /// @param amountOutMinimum The minimum amount of `tokenOut` to be received
+    /// @param sqrtPriceLimitX96 The price limit of the swap
+    /// @return exec An Execution object representing the swap operation
     function swapExactInputSingle(
         address smartAccount,
         IERC20 tokenIn,
-        IERC20 tokenOut,
         uint256 amountIn,
+        IERC20 tokenOut,
+        uint256 amountOutMinimum,
         uint160 sqrtPriceLimitX96
     )
         internal
@@ -41,31 +65,36 @@ library UniswapV3Integration {
     {
         exec = Execution({
             target: SWAPROUTER_ADDRESS,
-            value: 0,
-            callData: abi.encodeCall(
-                ISwapRouter.exactInputSingle,
-                (
-                    ISwapRouter.ExactInputSingleParams({
-                        tokenIn: address(tokenIn),
-                        tokenOut: address(tokenOut),
-                        fee: SWAPROUTER_DEFAULTFEE,
-                        recipient: smartAccount,
-                        deadline: block.timestamp,
-                        amountIn: amountIn,
-                        amountOutMinimum: 0,
-                        sqrtPriceLimitX96: sqrtPriceLimitX96
-                    })
-                )
+            value: address(tokenIn) == WRAPPED_NATIVE_ADDRESS ? amountIn : 0,
+            callData: abi.encodeWithSelector(
+                ISwapRouter.exactInputSingle.selector,
+                ISwapRouter.ExactInputSingleParams({
+                    tokenIn: address(tokenIn),
+                    tokenOut: address(tokenOut),
+                    fee: SWAPROUTER_DEFAULTFEE,
+                    recipient: smartAccount,
+                    deadline: block.timestamp,
+                    amountIn: amountIn,
+                    amountOutMinimum: amountOutMinimum,
+                    sqrtPriceLimitX96: sqrtPriceLimitX96
+                })
                 )
         });
     }
 
+    /// @notice Swaps `tokenIn` for exactly `amountOut` of `tokenOut` using the exact output method
+    /// @param smartAccount The address of the smart account
+    /// @param tokenIn The token to be swapped
+    /// @param amountInMaximum The maximum amount of `tokenIn` to be swapped
+    /// @param tokenOut The token to be received
+    /// @param amountOut The exact amount of `tokenOut` to be received
+    /// @return exec An Execution object representing the swap operation
     function swapExactOutputSingle(
         address smartAccount,
         IERC20 tokenIn,
+        uint256 amountInMaximum,
         IERC20 tokenOut,
-        uint256 amountOut,
-        uint256 amountInMaximum
+        uint256 amountOut
     )
         internal
         view
@@ -73,21 +102,19 @@ library UniswapV3Integration {
     {
         exec = Execution({
             target: SWAPROUTER_ADDRESS,
-            value: 0,
-            callData: abi.encodeCall(
-                ISwapRouter.exactOutputSingle,
-                (
-                    ISwapRouter.ExactOutputSingleParams({
-                        tokenIn: address(tokenIn),
-                        tokenOut: address(tokenOut),
-                        fee: SWAPROUTER_DEFAULTFEE,
-                        recipient: smartAccount,
-                        deadline: block.timestamp,
-                        amountOut: amountOut,
-                        amountInMaximum: amountInMaximum,
-                        sqrtPriceLimitX96: 0
-                    })
-                )
+            value: address(tokenIn) == WRAPPED_NATIVE_ADDRESS ? amountInMaximum : 0,
+            callData: abi.encodeWithSelector(
+                ISwapRouter.exactOutputSingle.selector,
+                ISwapRouter.ExactOutputSingleParams({
+                    tokenIn: address(tokenIn),
+                    tokenOut: address(tokenOut),
+                    fee: SWAPROUTER_DEFAULTFEE,
+                    recipient: smartAccount,
+                    deadline: block.timestamp,
+                    amountOut: amountOut,
+                    amountInMaximum: amountInMaximum,
+                    sqrtPriceLimitX96: 0
+                })
                 )
         });
     }


### PR DESCRIPTION
## Change Description
1. add support to swap `erc20-eth` and `eth-erc20`
2.  refactor `swapExactInputSingle` and `swapExactOutputSingle` functions to support all swap types
   - ERC20 -> ERC20
   - ETH -> ERC20
   - ERC20 -> ETH
3. Natspecs added
4. rename `approveAndSwap` to `approveAndSwapExactInput`

## Issue
https://github.com/rhinestonewtf/modulekit/issues/75