### PR TITLE
feat: track installed modules

### DIFF
--- a/src/ModuleKit.sol
+++ b/src/ModuleKit.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.23;
 
 /* solhint-disable no-unused-import */
-import { UserOpData, AccountInstance, RhinestoneModuleKit } from "./test/RhinestoneModuleKit.sol";
+import {
+    UserOpData,
+    AccountInstance,
+    RhinestoneModuleKit,
+    AccountType
+} from "./test/RhinestoneModuleKit.sol";
 import { ModuleKitHelpers } from "./test/ModuleKitHelpers.sol";
 import { ModuleKitUserOp } from "./test/ModuleKitUserOp.sol";
 import { PackedUserOperation } from "./external/ERC4337.sol";

--- a/src/test/ModuleKitHelpers.sol
+++ b/src/test/ModuleKitHelpers.sol
@@ -26,6 +26,7 @@ import {
     getAccountEnv as getAccountEnvFromStorage,
     getInstalledModules as getInstalledModulesFromStorage,
     writeInstalledModule as writeInstalledModuleToStorage,
+    removeInstalledModule as removeInstaleldModuleFromStorage,
     InstalledModule
 } from "./utils/Storage.sol";
 
@@ -265,18 +266,44 @@ library ModuleKitHelpers {
         userOpData.entrypoint = instance.aux.entrypoint;
     }
 
-    function getInstalledModules(AccountInstance memory)
+    function getInstalledModules(AccountInstance memory instance)
         internal
         view
         returns (InstalledModule[] memory)
     {
-        return getInstalledModulesFromStorage();
+        return getInstalledModulesFromStorage(instance.account);
     }
 
-    function writeInstalledModule(InstalledModule memory module) internal {
-        writeInstalledModuleToStorage(module);
+    function writeInstalledModule(
+        AccountInstance memory instance,
+        InstalledModule memory module
+    )
+        internal
+    {
+        writeInstalledModuleToStorage(module, instance.account);
     }
 
+    function removeInstalledModule(
+        AccountInstance memory instance,
+        uint256 moduleType,
+        address moduleAddress
+    )
+        internal
+    {
+        // Get installed modules for account
+        InstalledModule[] memory installedModules = getInstalledModules(instance);
+        // Find module to remove (not super scalable at high module counts)
+        for (uint256 i; i < installedModules.length; i++) {
+            if (
+                installedModules[i].moduleType == moduleType
+                    && installedModules[i].moduleAddress == moduleAddress
+            ) {
+                // Remove module from storage
+                removeInstaleldModuleFromStorage(i, instance.account);
+                return;
+            }
+        }
+    }
     /*//////////////////////////////////////////////////////////////////////////
                                 CONTROL FLOW
     //////////////////////////////////////////////////////////////////////////*/

--- a/src/test/ModuleKitHelpers.sol
+++ b/src/test/ModuleKitHelpers.sol
@@ -23,7 +23,10 @@ import {
     writeAccountEnv,
     getFactory,
     getHelper as getHelperFromStorage,
-    getAccountEnv as getAccountEnvFromStorage
+    getAccountEnv as getAccountEnvFromStorage,
+    getInstalledModules as getInstalledModulesFromStorage,
+    writeInstalledModule as writeInstalledModuleToStorage,
+    InstalledModule
 } from "./utils/Storage.sol";
 
 library ModuleKitHelpers {
@@ -260,6 +263,18 @@ library ModuleKitHelpers {
             txValidator: txValidator
         });
         userOpData.entrypoint = instance.aux.entrypoint;
+    }
+
+    function getInstalledModules(AccountInstance memory)
+        internal
+        view
+        returns (InstalledModule[] memory)
+    {
+        return getInstalledModulesFromStorage();
+    }
+
+    function writeInstalledModule(InstalledModule memory module) internal {
+        writeInstalledModuleToStorage(module);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/src/test/ModuleKitHelpers.sol
+++ b/src/test/ModuleKitHelpers.sol
@@ -267,7 +267,9 @@ library ModuleKitHelpers {
         userOpData.entrypoint = instance.aux.entrypoint;
     }
 
-    function getInstalledModules(AccountInstance memory instance)
+    function getInstalledModules(
+        AccountInstance memory instance
+    )
         internal
         view
         returns (InstalledModule[] memory)

--- a/src/test/utils/ERC4337Helpers.sol
+++ b/src/test/utils/ERC4337Helpers.sol
@@ -18,7 +18,10 @@ import {
     getExpectRevert,
     writeExpectRevert,
     getGasIdentifier,
-    writeGasIdentifier
+    writeGasIdentifier,
+    writeInstalledModule,
+    getInstalledModules,
+    InstalledModule
 } from "./Storage.sol";
 
 library ERC4337Helpers {
@@ -69,6 +72,14 @@ library ERC4337Helpers {
                         writeExpectRevert(0);
                     }
                 }
+            }
+            // ModuleInstalled(uint256, address)
+            else if (
+                logs[i].topics[0]
+                    == 0xd21d0b289f126c4b473ea641963e766833c2f13866e4ff480abd787c100ef123
+            ) {
+                (uint256 moduleType, address module) = abi.decode(logs[i].data, (uint256, address));
+                writeInstalledModule(InstalledModule(moduleType, module));
             }
         }
         isExpectRevert = getExpectRevert();

--- a/src/test/utils/Storage.sol
+++ b/src/test/utils/Storage.sol
@@ -142,10 +142,11 @@ struct InstalledModule {
     address moduleAddress;
 }
 
-// Adds new address to the installed module array
-// The array stores structs with the module type and the module address
-function writeInstalledModule(InstalledModule memory module) {
-    bytes32 lengthSlot = keccak256(abi.encode("ModuleKit.InstalledModuleSlot"));
+// Adds new address to the installed module array for the given account
+function writeInstalledModule(InstalledModule memory module, address account) {
+    bytes32 lengthSlot = keccak256(
+        abi.encode("ModuleKit.InstalledModuleSlot.", keccak256(abi.encodePacked(account)))
+    );
     bytes32 elementSlot = keccak256(abi.encode(lengthSlot));
     uint256 moduleType = module.moduleType;
     address moduleAddress = module.moduleAddress;
@@ -163,8 +164,10 @@ function writeInstalledModule(InstalledModule memory module) {
 }
 
 // Removes all installed modules
-function clearInstalledModules() {
-    bytes32 lengthSlot = keccak256(abi.encode("ModuleKit.InstalledModuleSlot"));
+function clearInstalledModules(address account) {
+    bytes32 lengthSlot = keccak256(
+        abi.encode("ModuleKit.InstalledModuleSlot.", keccak256(abi.encodePacked(account)))
+    );
     bytes32 elementSlot = keccak256(abi.encode(lengthSlot));
     assembly {
         sstore(lengthSlot, 0)
@@ -176,8 +179,10 @@ function clearInstalledModules() {
 }
 
 // Removes a specific installed module
-function removeInstalledModule(uint256 index) {
-    bytes32 lengthSlot = keccak256(abi.encode("ModuleKit.InstalledModuleSlot"));
+function removeInstalledModule(uint256 index, address account) {
+    bytes32 lengthSlot = keccak256(
+        abi.encode("ModuleKit.InstalledModuleSlot.", keccak256(abi.encodePacked(account)))
+    );
     bytes32 elementSlot = keccak256(abi.encode(lengthSlot));
     assembly {
         // Get the length of the array
@@ -203,9 +208,11 @@ function removeInstalledModule(uint256 index) {
     }
 }
 
-// Returns all installed modules as an array of InstalledModule structs
-function getInstalledModules() view returns (InstalledModule[] memory modules) {
-    bytes32 lengthSlot = keccak256(abi.encode("ModuleKit.InstalledModuleSlot"));
+// Returns all installed modules for the given account
+function getInstalledModules(address account) view returns (InstalledModule[] memory modules) {
+    bytes32 lengthSlot = keccak256(
+        abi.encode("ModuleKit.InstalledModuleSlot.", keccak256(abi.encodePacked(account)))
+    );
     bytes32 elementSlot = keccak256(abi.encode(lengthSlot));
     assembly {
         // Get the length of the array from storage

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -13,7 +13,6 @@ import {
 } from "src/external/ERC7579.sol";
 import { getAccountType, InstalledModule } from "src/test/utils/Storage.sol";
 import { toString } from "src/test/utils/Vm.sol";
-import { AccountType } from "src/test/RhinestoneModuleKit.sol";
 
 contract ERC7579DifferentialModuleKitLibTest is BaseTest {
     using ModuleKitHelpers for *;

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -137,7 +137,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         assertTrue(validator1Enabled);
     }
 
-    function test_getInstalledModules() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules() public whenEnvIsNotKernel {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -178,7 +178,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_DifferentInstances() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules_DifferentInstances() public whenEnvIsNotKernel {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -259,7 +259,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_AfterUninstall() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules_AfterUninstall() public whenEnvIsNotKernel {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -552,9 +552,8 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
                                 MODIFIERS
     //////////////////////////////////////////////////////////////*/
 
-    // Used to skip tests when env is kernel or safe as sometimes
-    // they don't emit events on module installation
-    modifier whenEnvIsNotKernelOrSafe() {
+    // Used to skip tests when env is kernel as they don't emit events on module installation
+    modifier whenEnvIsNotKernel() {
         AccountType env = ModuleKitHelpers.getAccountType();
         if (env == AccountType.KERNEL) {
             return;

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -138,7 +138,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         assertTrue(validator1Enabled);
     }
 
-    function test_getInstalledModules() public {
+    function test_getInstalledModules() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -176,7 +176,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_DifferentInstances() public {
+    function test_getInstalledModules_DifferentInstances() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -253,7 +253,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_AfterUninstall() public {
+    function test_getInstalledModules_AfterUninstall() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -535,5 +535,19 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         newInstance.deployAccount();
 
         assertTrue(newInstance.account.code.length > 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                MODIFIERS
+    //////////////////////////////////////////////////////////////*/
+
+    // Used to skip tests when env is kernel or safe as sometimes they don't emit events on module
+    // installation
+    modifier whenEnvIsNotKernelOrSafe() {
+        AccountType env = ModuleKitHelpers.getAccountType();
+        if (env == AccountType.KERNEL || env == AccountType.SAFE) {
+            return;
+        }
+        _;
     }
 }

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -221,9 +221,6 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
         // Deploy new instance using current env
         AccountInstance memory newInstance = makeAccountInstance("newSalt");
-        assertTrue(newInstance.account.code.length == 0);
-        newInstance.deployAccount();
-        assertTrue(newInstance.account.code.length > 0);
 
         // Install modules on new instance
         newInstance.installModule({
@@ -239,12 +236,12 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
         // Get installed modules on new instance
         InstalledModule[] memory newModules = newInstance.getInstalledModules();
-        assertTrue(newModules.length == 2);
+        assertTrue(newModules.length == (env == AccountType.SAFE ? 3 : 2));
         assertTrue(
-            newModules[0].moduleAddress == newValidator
-                && newModules[1].moduleAddress == newExecutor
-                && newModules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && newModules[1].moduleType == MODULE_TYPE_EXECUTOR
+            newModules[expectedIndex].moduleAddress == newValidator
+                && newModules[expectedIndex + 1].moduleAddress == newExecutor
+                && newModules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && newModules[expectedIndex + 1].moduleType == MODULE_TYPE_EXECUTOR
         );
 
         // Old instance modules should still be the same

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -138,7 +138,10 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         assertTrue(validator1Enabled);
     }
 
-    function test_getInstalledModules() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules()
+        public
+        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
+    {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -176,7 +179,10 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_DifferentInstances() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules_DifferentInstances()
+        public
+        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
+    {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -253,7 +259,10 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         );
     }
 
-    function test_getInstalledModules_AfterUninstall() public whenEnvIsNotKernelOrSafe {
+    function test_getInstalledModules_AfterUninstall()
+        public
+        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
+    {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -543,8 +552,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
     // Used to skip tests when env is kernel or safe as sometimes
     // they don't emit events on module installation
-    modifier whenEnvIsNotKernelOrSafe() {
-        AccountType _env = ModuleKitHelpers.getAccountType();
+    modifier whenEnvIsNotKernelOrSafe(AccountType _env) {
         if (_env == AccountType.KERNEL || _env == AccountType.SAFE) {
             return;
         }

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -301,9 +301,9 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
         assertTrue(modules.length == 2);
         assertTrue(
-            modules[1].moduleAddress == newValidator1 && modules[0].moduleAddress == newExecutor
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[0].moduleType == MODULE_TYPE_EXECUTOR
+            modules[0].moduleAddress == newValidator1 && modules[1].moduleAddress == newExecutor
+                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[1].moduleType == MODULE_TYPE_EXECUTOR
         );
     }
 

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -138,10 +138,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         assertTrue(validator1Enabled);
     }
 
-    function test_getInstalledModules()
-        public
-        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
-    {
+    function test_getInstalledModules() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -158,31 +155,31 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         });
 
         InstalledModule[] memory modules = instance.getInstalledModules();
-        assertTrue(modules.length == 2);
+        AccountType env = ModuleKitHelpers.getAccountType();
+        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
+        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
         modules = instance.getInstalledModules();
-
-        assertTrue(modules.length == 3);
+        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[2].moduleAddress == newExecutor
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[2].moduleType == MODULE_TYPE_EXECUTOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex + 2].moduleAddress == newExecutor
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
         );
     }
 
-    function test_getInstalledModules_DifferentInstances()
-        public
-        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
-    {
+    function test_getInstalledModules_DifferentInstances() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -199,24 +196,27 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         });
 
         InstalledModule[] memory modules = instance.getInstalledModules();
-        assertTrue(modules.length == 2);
+        AccountType env = ModuleKitHelpers.getAccountType();
+        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
+        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
         modules = instance.getInstalledModules();
-
-        assertTrue(modules.length == 3);
+        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[2].moduleAddress == newExecutor
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[2].moduleType == MODULE_TYPE_EXECUTOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex + 2].moduleAddress == newExecutor
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
         );
 
         // Deploy new instance using current env
@@ -249,20 +249,18 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
         // Old instance modules should still be the same
         modules = instance.getInstalledModules();
-        assertTrue(modules.length == 3);
+        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[2].moduleAddress == newExecutor
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[2].moduleType == MODULE_TYPE_EXECUTOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex + 2].moduleAddress == newExecutor
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
         );
     }
 
-    function test_getInstalledModules_AfterUninstall()
-        public
-        whenEnvIsNotKernelOrSafe(ModuleKitHelpers.getAccountType())
-    {
+    function test_getInstalledModules_AfterUninstall() public whenEnvIsNotKernelOrSafe {
         address newValidator = address(new MockValidator());
         address newValidator1 = address(new MockValidator());
         vm.label(newValidator, "2nd validator");
@@ -279,24 +277,28 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         });
 
         InstalledModule[] memory modules = instance.getInstalledModules();
-        assertTrue(modules.length == 2);
+        AccountType env = ModuleKitHelpers.getAccountType();
+        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
+        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
         modules = instance.getInstalledModules();
 
-        assertTrue(modules.length == 3);
+        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
         assertTrue(
-            modules[0].moduleAddress == newValidator && modules[1].moduleAddress == newValidator1
-                && modules[2].moduleAddress == newExecutor
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[2].moduleType == MODULE_TYPE_EXECUTOR
+            modules[expectedIndex].moduleAddress == newValidator
+                && modules[expectedIndex + 1].moduleAddress == newValidator1
+                && modules[expectedIndex + 2].moduleAddress == newExecutor
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
         );
 
         // Uninstall module
@@ -309,11 +311,12 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         // Get installed modules
         modules = instance.getInstalledModules();
 
-        assertTrue(modules.length == 2);
+        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
         assertTrue(
-            modules[0].moduleAddress == newValidator1 && modules[1].moduleAddress == newExecutor
-                && modules[0].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[1].moduleType == MODULE_TYPE_EXECUTOR
+            modules[expectedIndex].moduleAddress == newValidator1
+                && modules[expectedIndex + 1].moduleAddress == newExecutor
+                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
+                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_EXECUTOR
         );
     }
 
@@ -552,8 +555,9 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
     // Used to skip tests when env is kernel or safe as sometimes
     // they don't emit events on module installation
-    modifier whenEnvIsNotKernelOrSafe(AccountType _env) {
-        if (_env == AccountType.KERNEL || _env == AccountType.SAFE) {
+    modifier whenEnvIsNotKernelOrSafe() {
+        AccountType env = ModuleKitHelpers.getAccountType();
+        if (env == AccountType.KERNEL) {
             return;
         }
         _;

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -13,7 +13,6 @@ import {
 } from "src/external/ERC7579.sol";
 import { getAccountType, InstalledModule } from "src/test/utils/Storage.sol";
 import { toString } from "src/test/utils/Vm.sol";
-import { console2 } from "forge-std/console2.sol";
 
 contract ERC7579DifferentialModuleKitLibTest is BaseTest {
     using ModuleKitHelpers for *;

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -221,6 +221,9 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
 
         // Deploy new instance using current env
         AccountInstance memory newInstance = makeAccountInstance("newSalt");
+        assertTrue(newInstance.account.code.length == 0);
+        newInstance.deployAccount();
+        assertTrue(newInstance.account.code.length > 0);
 
         // Install modules on new instance
         newInstance.installModule({

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -13,6 +13,7 @@ import {
 } from "src/external/ERC7579.sol";
 import { getAccountType, InstalledModule } from "src/test/utils/Storage.sol";
 import { toString } from "src/test/utils/Vm.sol";
+import { console2 } from "forge-std/console2.sol";
 
 contract ERC7579DifferentialModuleKitLibTest is BaseTest {
     using ModuleKitHelpers for *;
@@ -153,28 +154,25 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
             data: ""
         });
 
-        InstalledModule[] memory modules = instance.getInstalledModules();
-        AccountType env = ModuleKitHelpers.getAccountType();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
-        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                2, [newValidator, newValidator1], [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR]
+            ),
+            instance
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
-        modules = instance.getInstalledModules();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex + 2].moduleAddress == newExecutor
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
+
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                3,
+                [newValidator, newValidator1, newExecutor],
+                [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR]
+            ),
+            instance
         );
     }
 
@@ -194,28 +192,25 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
             data: ""
         });
 
-        InstalledModule[] memory modules = instance.getInstalledModules();
-        AccountType env = ModuleKitHelpers.getAccountType();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
-        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                2, [newValidator, newValidator1], [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR]
+            ),
+            instance
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
-        modules = instance.getInstalledModules();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex + 2].moduleAddress == newExecutor
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
+
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                3,
+                [newValidator, newValidator1, newExecutor],
+                [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR]
+            ),
+            instance
         );
 
         // Deploy new instance using current env
@@ -236,26 +231,22 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
             data: ""
         });
 
-        // Get installed modules on new instance
-        InstalledModule[] memory newModules = newInstance.getInstalledModules();
-        assertTrue(newModules.length == (env == AccountType.SAFE ? 3 : 2));
-        assertTrue(
-            newModules[expectedIndex].moduleAddress == newValidator
-                && newModules[expectedIndex + 1].moduleAddress == newExecutor
-                && newModules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && newModules[expectedIndex + 1].moduleType == MODULE_TYPE_EXECUTOR
+        // Assert installed modules on new instance
+        this._getModulesAndAssert(
+            abi.encode(
+                2, [newValidator, newExecutor], [MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR]
+            ),
+            newInstance
         );
 
         // Old instance modules should still be the same
-        modules = instance.getInstalledModules();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex + 2].moduleAddress == newExecutor
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
+        this._getModulesAndAssert(
+            abi.encode(
+                3,
+                [newValidator, newValidator1, newExecutor],
+                [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR]
+            ),
+            instance
         );
     }
 
@@ -275,29 +266,25 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
             data: ""
         });
 
-        InstalledModule[] memory modules = instance.getInstalledModules();
-        AccountType env = ModuleKitHelpers.getAccountType();
-        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
-        uint256 expectedIndex = env == AccountType.SAFE ? 1 : 0;
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                2, [newValidator, newValidator1], [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR]
+            ),
+            instance
         );
 
         address newExecutor = address(new MockExecutor());
         instance.installModule({ moduleTypeId: MODULE_TYPE_EXECUTOR, module: newExecutor, data: "" });
-        modules = instance.getInstalledModules();
 
-        assertTrue(modules.length == (env == AccountType.SAFE ? 4 : 3));
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator
-                && modules[expectedIndex + 1].moduleAddress == newValidator1
-                && modules[expectedIndex + 2].moduleAddress == newExecutor
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 2].moduleType == MODULE_TYPE_EXECUTOR
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                3, // length
+                [newValidator, newValidator1, newExecutor], // expectedAddresses
+                [MODULE_TYPE_VALIDATOR, MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR] // expectedTypes
+            ),
+            instance
         );
 
         // Uninstall module
@@ -307,15 +294,12 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
             data: ""
         });
 
-        // Get installed modules
-        modules = instance.getInstalledModules();
-
-        assertTrue(modules.length == (env == AccountType.SAFE ? 3 : 2));
-        assertTrue(
-            modules[expectedIndex].moduleAddress == newValidator1
-                && modules[expectedIndex + 1].moduleAddress == newExecutor
-                && modules[expectedIndex].moduleType == MODULE_TYPE_VALIDATOR
-                && modules[expectedIndex + 1].moduleType == MODULE_TYPE_EXECUTOR
+        // Assert installed modules
+        this._getModulesAndAssert(
+            abi.encode(
+                2, [newValidator1, newExecutor], [MODULE_TYPE_VALIDATOR, MODULE_TYPE_EXECUTOR]
+            ),
+            instance
         );
     }
 
@@ -536,7 +520,7 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
     }
 
     /*//////////////////////////////////////////////////////////////
-                                INTERNAL
+                                HELPERS
     //////////////////////////////////////////////////////////////*/
 
     function _usingAccountEnv(string memory env) internal usingAccountEnv(env.toAccountType()) {
@@ -546,6 +530,38 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
         newInstance.deployAccount();
 
         assertTrue(newInstance.account.code.length > 0);
+    }
+
+    function _getModulesAndAssert(
+        bytes calldata expectedResultBytes,
+        AccountInstance memory _instance
+    )
+        public
+        view
+    {
+        InstalledModule[] memory modules = _instance.getInstalledModules();
+        // Parse length
+        uint256 length = abi.decode(expectedResultBytes[0:32], (uint256));
+        // Parse addresses and types
+        address[] memory expectedAddresses = new address[](length);
+        uint256[] memory expectedTypes = new uint256[](length);
+        for (uint256 i = 0; i < length; i++) {
+            expectedAddresses[i] =
+                abi.decode(expectedResultBytes[32 + i * 32:64 + i * 32], (address));
+            expectedTypes[i] = abi.decode(
+                expectedResultBytes[32 + length * 32 + i * 32:64 + length * 32 + i * 32], (uint256)
+            );
+        }
+        // Assert expected modules length
+        assertTrue(
+            modules.length == length + (instance.getAccountType() == AccountType.SAFE ? 1 : 0)
+        );
+        // AccountType.SAFE has 1 extra module added during setup, skip it
+        uint256 index = instance.getAccountType() == AccountType.SAFE ? 1 : 0;
+        for (uint256 i = 0; i < length; i++) {
+            assertTrue(modules[index + i].moduleAddress == expectedAddresses[i]);
+            assertTrue(modules[index + i].moduleType == expectedTypes[i]);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/Diff.t.sol
+++ b/test/Diff.t.sol
@@ -541,11 +541,11 @@ contract ERC7579DifferentialModuleKitLibTest is BaseTest {
                                 MODIFIERS
     //////////////////////////////////////////////////////////////*/
 
-    // Used to skip tests when env is kernel or safe as sometimes they don't emit events on module
-    // installation
+    // Used to skip tests when env is kernel or safe as sometimes
+    // they don't emit events on module installation
     modifier whenEnvIsNotKernelOrSafe() {
-        AccountType env = ModuleKitHelpers.getAccountType();
-        if (env == AccountType.KERNEL || env == AccountType.SAFE) {
+        AccountType _env = ModuleKitHelpers.getAccountType();
+        if (_env == AccountType.KERNEL || _env == AccountType.SAFE) {
             return;
         }
         _;


### PR DESCRIPTION
- adds listeners for `ModuleInstalled(uint256, address)` and `ModuleUninstalled(uint256, address)` events
- when a module is installed it stores the installed module per account in a linked list using `writeInstalledModule()`, when a module is uninstalled it is removed using `removeInstalledModule()`.
- allows querying of all currently installed modules per account instance using `getInstalledModules()`
- currently the tests are skipped for Kernel account type, because the Kernel implementation doesn't always emit an event when a module is installed