### PR TITLE
changing error for AlreadyInitialized to not conflict with ownable

### DIFF
--- a/src/accounts/common/interfaces/IERC7579Module.sol
+++ b/src/accounts/common/interfaces/IERC7579Module.sol
@@ -14,7 +14,7 @@ uint256 constant MODULE_TYPE_FALLBACK = 3;
 uint256 constant MODULE_TYPE_HOOK = 4;
 
 interface IModule {
-    error AlreadyInitialized(address smartAccount);
+    error ModuleAlreadyInitialized(address smartAccount);
     error NotInitialized(address smartAccount);
 
     /**

--- a/src/accounts/kernel/interfaces/IERC7579Modules.sol
+++ b/src/accounts/kernel/interfaces/IERC7579Modules.sol
@@ -6,7 +6,7 @@ import { PackedUserOperation } from
     "@ERC4337/account-abstraction/contracts/core/UserOperationLib.sol";
 
 interface IModule {
-    error AlreadyInitialized(address smartAccount);
+    error ModuleAlreadyInitialized(address smartAccount);
     error NotInitialized(address smartAccount);
 
     /**

--- a/src/module-bases/SchedulingBase.sol
+++ b/src/module-bases/SchedulingBase.sol
@@ -40,7 +40,7 @@ abstract contract SchedulingBase is ERC7579ExecutorBase {
     function _onInstall(bytes calldata packedSchedulingData) internal {
         address account = msg.sender;
         if (isInitialized(account)) {
-            revert AlreadyInitialized(account);
+            revert ModuleAlreadyInitialized(account);
         }
 
         _createExecution({ orderData: packedSchedulingData });


### PR DESCRIPTION
Currently this error signature is conflicting whenever Ownable.sol is used in a module. 

```sh
Error (9097): Identifier already declared.
  --> node_modules/solady/src/auth/Ownable.sol:29:5:
   |
29 |     error AlreadyInitialized();
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The previous declaration is here:
  --> node_modules/@rhinestone/modulekit/src/accounts/common/interfaces/IERC7579Module.sol:17:5:
   |
17 |     error AlreadyInitialized(address smartAccount);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Changing this should be a easy win
